### PR TITLE
Competing consumers

### DIFF
--- a/Erazer.DAL/Events/EventStoreSubscription.cs
+++ b/Erazer.DAL/Events/EventStoreSubscription.cs
@@ -53,7 +53,11 @@ namespace Erazer.DAL.Events
 
         private Task EventAppeared(EventStorePersistentSubscriptionBase subscription, ResolvedEvent resolvedEvent)
         {
-            _telemetryClient.TrackEvent("New Event", new Dictionary<string, string> { { "Type", resolvedEvent.Event.EventType } });
+            _telemetryClient.TrackEvent("New event appeared from EventStore (read model)", new Dictionary<string, string> {
+                { "Type", resolvedEvent.Event.EventType },
+                { "EventNumber", resolvedEvent.Event.EventNumber.ToString() },
+                { "Created (Epoch)", resolvedEvent.Event.CreatedEpoch.ToString() }
+            });
 
             var @event = _mapper.Map<IEvent>(resolvedEvent);
             return _mediator.Publish(@event);

--- a/Erazer.DAL/Events/EventStoreSubscription.cs
+++ b/Erazer.DAL/Events/EventStoreSubscription.cs
@@ -1,0 +1,67 @@
+﻿using AutoMapper;
+using Erazer.Framework.Domain;
+using Erazer.Framework.Events;
+using EventStore.ClientAPI;
+using MediatR;
+using Microsoft.ApplicationInsights;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Erazer.DAL.Events
+{
+    public class EventStoreSubscription<T> : ISubscription<T>, IDisposable where T : AggregateRoot
+    {
+        private const string _groupName = "erazercqrs";
+
+        private readonly IEventStoreConnection _eventStoreConnection;
+        private readonly IMapper _mapper;
+        private readonly IMediator _mediator;
+        private readonly TelemetryClient _telemetryClient;
+
+        private EventStorePersistentSubscriptionBase EventStorePersistentSubscriptionBase { get; set; }
+
+        public EventStoreSubscription(IEventStoreConnection eventStoreConnection, IMapper mapper, IMediator mediator, TelemetryClient telemeteryClient)
+        {
+            _eventStoreConnection = eventStoreConnection;
+            _mapper = mapper;
+            _mediator = mediator;
+            _telemetryClient = telemeteryClient;
+        }
+
+        public void Connect()
+        {
+            var streamName = $"$ce-{typeof(T).Name}";
+
+            EventStorePersistentSubscriptionBase = _eventStoreConnection.ConnectToPersistentSubscription(
+                   streamName,
+                   _groupName,
+                   EventAppeared,
+                   SubscriptionDropped
+            );
+        }
+
+        private void SubscriptionDropped(EventStorePersistentSubscriptionBase subscription, SubscriptionDropReason reason, Exception ex)
+        {
+            _telemetryClient.TrackEvent("SubscriptionDropped", new Dictionary<string, string> {{ "Reason", reason.ToString() }});
+
+            if (ex != null)
+                _telemetryClient.TrackException(ex);
+
+            Connect();
+        }
+
+        private Task EventAppeared(EventStorePersistentSubscriptionBase subscription, ResolvedEvent resolvedEvent)
+        {
+            _telemetryClient.TrackEvent("New Event", new Dictionary<string, string> { { "Type", resolvedEvent.Event.EventType } });
+
+            var @event = _mapper.Map<IEvent>(resolvedEvent);
+            return _mediator.Publish(@event);
+        }
+
+        public void Dispose()
+        {
+            EventStorePersistentSubscriptionBase.Stop(TimeSpan.FromSeconds(15));
+        }
+    }
+}

--- a/Erazer.DAL/Events/ISubscription.cs
+++ b/Erazer.DAL/Events/ISubscription.cs
@@ -2,6 +2,7 @@
 
 namespace Erazer.DAL.Events
 {
+    // TODO: Is this interface in the correct place?
     public interface ISubscription<T> where T : AggregateRoot
     {
         void Connect();

--- a/Erazer.DAL/Events/ISubscription.cs
+++ b/Erazer.DAL/Events/ISubscription.cs
@@ -1,0 +1,9 @@
+﻿using Erazer.Framework.Domain;
+
+namespace Erazer.DAL.Events
+{
+    public interface ISubscription<T> where T : AggregateRoot
+    {
+        void Connect();
+    }
+}

--- a/Erazer.DAL/Infrastructure/EventStore/EventStoreFactory.cs
+++ b/Erazer.DAL/Infrastructure/EventStore/EventStoreFactory.cs
@@ -26,10 +26,11 @@ namespace Erazer.DAL.Infrastucture.EventStore
         {
             try
             {
+                // TODO Use different settings on different env's
                 var settings = ConnectionSettings.Create()
-                                    .SetHeartbeatInterval(TimeSpan.FromSeconds(5))
+                                    .SetHeartbeatTimeout(TimeSpan.FromSeconds(5))
                                     .UseConsoleLogger();
-
+                                    
                 var connection = EventStoreConnection.Create(_options.Value.ConnectionString, settings);
                 connection.ConnectAsync().Wait();
 

--- a/Erazer.DAL/Infrastructure/EventStore/EventStoreFactory.cs
+++ b/Erazer.DAL/Infrastructure/EventStore/EventStoreFactory.cs
@@ -4,7 +4,7 @@ using EventStore.ClientAPI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace Erazer.DAL.WriteModel
+namespace Erazer.DAL.Infrastucture.EventStore
 {
     public class EventStoreFactory : IFactory<IEventStoreConnection>
     {
@@ -26,7 +26,11 @@ namespace Erazer.DAL.WriteModel
         {
             try
             {
-                var connection = EventStoreConnection.Create(_options.Value.ConnectionString);
+                var settings = ConnectionSettings.Create()
+                                    .SetHeartbeatInterval(TimeSpan.FromSeconds(5))
+                                    .UseConsoleLogger();
+
+                var connection = EventStoreConnection.Create(_options.Value.ConnectionString, settings);
                 connection.ConnectAsync().Wait();
 
                 _logger.LogInformation($"Created a succesful connection with the 'GetEventStore' server\n\t ConnectionString: {_options.Value.ConnectionString}\n\t");

--- a/Erazer.DAL/Infrastructure/EventStore/EventStoreSettings.cs
+++ b/Erazer.DAL/Infrastructure/EventStore/EventStoreSettings.cs
@@ -1,4 +1,4 @@
-﻿namespace Erazer.DAL.WriteModel
+﻿namespace Erazer.DAL.Infrastucture.EventStore
 {
     public class EventStoreSettings
     {

--- a/Erazer.DAL/Infrastructure/EventStore/Mapping.cs
+++ b/Erazer.DAL/Infrastructure/EventStore/Mapping.cs
@@ -6,7 +6,7 @@ using EventStore.ClientAPI;
 using Newtonsoft.Json;
 using Erazer.Web.Shared;
 
-namespace Erazer.DAL.WriteModel
+namespace Erazer.DAL.Infrastucture.EventStore
 {
     public class Mapping : Profile
     {
@@ -17,8 +17,7 @@ namespace Erazer.DAL.WriteModel
 
             CreateMap<ResolvedEvent, IEvent>()
                 .ConstructUsing(src => JsonConvert.DeserializeObject<IEvent>(new UTF8Encoding().GetString(src.Event.Data), JsonSettings.DefaultSettings))
-                .ForMember(dest => dest.Version, opt => opt.MapFrom(src => src.Event.EventNumber))
-                .ForMember(dest => dest.AggregateRootId, opt => opt.MapFrom(src => src.Event.EventStreamId));
+                .ForMember(dest => dest.Version, opt => opt.MapFrom(src => src.Event.EventNumber));
         }
     }
 }

--- a/Erazer.DAL/Infrastructure/MongoDb/MongoDbFactory.cs
+++ b/Erazer.DAL/Infrastructure/MongoDb/MongoDbFactory.cs
@@ -4,12 +4,11 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using MongoDB.Driver;
-using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Events;
 using System;
 
-namespace Erazer.DAL.ReadModel.Base
+namespace Erazer.DAL.Infrastucture.MongoDb
 {
     public class MongoDbFactory : IFactory<IMongoDatabase>
     {

--- a/Erazer.DAL/Infrastructure/MongoDb/MongoDbSettings.cs
+++ b/Erazer.DAL/Infrastructure/MongoDb/MongoDbSettings.cs
@@ -1,4 +1,4 @@
-﻿namespace Erazer.DAL.ReadModel.Base
+﻿namespace Erazer.DAL.Infrastucture.MongoDb
 {
     public class MongoDbSettings
     {

--- a/Erazer.Framework/Cache/CacheRepository.cs
+++ b/Erazer.Framework/Cache/CacheRepository.cs
@@ -27,7 +27,7 @@ namespace Erazer.Framework.Cache
                 if (_cache.IsTracked(aggregateId))
                 {
                     aggregate = (T) _cache.Get(aggregateId);
-                    var events = (await _eventStore.Get(aggregateId, aggregate.Version)).ToList();
+                    var events = (await _eventStore.Get<T>(aggregateId, aggregate.Version)).ToList();
 
                     // Check if there are any new events added between save in cache and now!
                     // If this is the case remove aggregate from cache and retrieve it.

--- a/Erazer.Framework/Domain/AggregateRepository.cs
+++ b/Erazer.Framework/Domain/AggregateRepository.cs
@@ -18,7 +18,7 @@ namespace Erazer.Framework.Domain
 
         public async Task<T> Get<T>(Guid aggregateId) where T : AggregateRoot
         {
-            var events = await _eventStore.Get(aggregateId, -1);
+            var events = await _eventStore.Get<T>(aggregateId, -1);
             var eventList = events as IList<IEvent> ?? events.ToList();
 
             if (!eventList.Any())
@@ -34,7 +34,7 @@ namespace Erazer.Framework.Domain
         public Task Save<T>(T aggregate) where T : AggregateRoot
         {
             var changes = aggregate.FlushChanges();
-            return _eventStore.Save(aggregate.Id, changes);
+            return _eventStore.Save<T>(aggregate.Id, changes);
         }
     }
 }

--- a/Erazer.Framework/Events/IEventStore.cs
+++ b/Erazer.Framework/Events/IEventStore.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Erazer.Framework.Domain;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -6,7 +7,7 @@ namespace Erazer.Framework.Events
 {
     public interface IEventStore
     {
-        Task Save(Guid aggregateId, IEnumerable<IEvent> events);
-        Task<IEnumerable<IEvent>> Get(Guid aggregateId, int fromVersion);
+        Task Save<T>(Guid aggregateId, IEnumerable<IEvent> events) where T : AggregateRoot;
+        Task<IEnumerable<IEvent>> Get<T>(Guid aggregateId, int fromVersion) where T : AggregateRoot;
     }
 }

--- a/Erazer.Web.ReadAPI/Extensions/ServiceCollectionExtensions.cs
+++ b/Erazer.Web.ReadAPI/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,20 @@
+﻿using Erazer.DAL.Events;
+using Erazer.Framework.Domain;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Erazer.Web.ReadAPI.Extensions
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static void StartSubscriber<T>(this IServiceCollection collection) where T: AggregateRoot
+        {
+            collection.AddSingleton(typeof(ISubscription<>), typeof(EventStoreSubscription<>));
+
+            // Build the intermediate service provider
+            var sp = collection.BuildServiceProvider();
+            var service = sp.GetService<ISubscription<T>>();
+
+            service.Connect();
+        }
+    }
+}

--- a/Erazer.Web.ReadAPI/Startup.cs
+++ b/Erazer.Web.ReadAPI/Startup.cs
@@ -15,11 +15,14 @@ using Erazer.Servicebus.Extensions;
 using Erazer.Shared.Extensions.DependencyInjection;
 using Erazer.Web.ReadAPI.Extensions;
 using Erazer.Web.Shared.Telemetery;
-using Erazer.DAL.ReadModel.Base;
 using Erazer.DAL.ReadModel.Repositories;
 using Erazer.Domain.Infrastructure.Repositories;
 using Erazer.Framework.FrontEnd;
 using Erazer.Web.Read.API.Websockets;
+using Erazer.DAL.Infrastucture.MongoDb;
+using Erazer.Domain;
+using Erazer.DAL.Infrastucture.EventStore;
+using EventStore.ClientAPI;
 
 namespace Erazer.Web.ReadAPI
 {
@@ -43,16 +46,18 @@ namespace Erazer.Web.ReadAPI
         {
             services.AddSingleton<IConfiguration>(_configuration);
             services.Configure<MongoDbSettings>(_configuration.GetSection("MongoDbSettings"));
-            services.Configure<AzureServiceBusSettings>(_configuration.GetSection("AzureServiceBusSettings"));
+            // services.Configure<AzureServiceBusSettings>(_configuration.GetSection("AzureServiceBusSettings"));
             services.Configure<WebsocketSettings>(_configuration.GetSection("WebsocketSettings"));
+            services.Configure<EventStoreSettings>(_configuration.GetSection("EventStoreSettings"));
 
             // Add Singleton TelemeterClient
             services.AddSingletonFactory<TelemetryClient, TelemeteryFactory>();
 
             // Add 'Infrasructure' Providers
             services.AddSingletonFactory<IMongoDatabase, MongoDbFactory>();
-            services.AddSingletonFactory<IQueueClient, QueueClientFactory>();
+            // services.AddSingletonFactory<IQueueClient, QueueClientFactory>();
             services.AddSingleton<IWebsocketEmittor, WebsocketEmittor>();
+            services.AddSingletonFactory<IEventStoreConnection, EventStoreFactory>();
 
             services.AddAutoMapper();
             services.AddMediatR();
@@ -65,7 +70,8 @@ namespace Erazer.Web.ReadAPI
             services.AddScoped<IPriorityQueryRepository, PriorityRepository>();
 
             // CQRS
-            services.StartEventReciever();
+            //services.StartEventReciever();
+            services.StartSubscriber<Ticket>();
 
             // Add MVC
             services.AddCors();

--- a/Erazer.Web.ReadAPI/Startup.cs
+++ b/Erazer.Web.ReadAPI/Startup.cs
@@ -46,7 +46,6 @@ namespace Erazer.Web.ReadAPI
         {
             services.AddSingleton<IConfiguration>(_configuration);
             services.Configure<MongoDbSettings>(_configuration.GetSection("MongoDbSettings"));
-            // services.Configure<AzureServiceBusSettings>(_configuration.GetSection("AzureServiceBusSettings"));
             services.Configure<WebsocketSettings>(_configuration.GetSection("WebsocketSettings"));
             services.Configure<EventStoreSettings>(_configuration.GetSection("EventStoreSettings"));
 
@@ -55,14 +54,13 @@ namespace Erazer.Web.ReadAPI
 
             // Add 'Infrasructure' Providers
             services.AddSingletonFactory<IMongoDatabase, MongoDbFactory>();
-            // services.AddSingletonFactory<IQueueClient, QueueClientFactory>();
             services.AddSingleton<IWebsocketEmittor, WebsocketEmittor>();
             services.AddSingletonFactory<IEventStoreConnection, EventStoreFactory>();
 
             services.AddAutoMapper();
             services.AddMediatR();
 
-            // TODO Place in seperate file (Arne)
+            // TODO Place in seperate file (Arne) > services.AddTicket();
             // Query repositories
             services.AddScoped<ITicketQueryRepository, TicketRepository>();
             services.AddScoped<ITicketEventQueryRepository, TicketEventRepository>();
@@ -70,7 +68,6 @@ namespace Erazer.Web.ReadAPI
             services.AddScoped<IPriorityQueryRepository, PriorityRepository>();
 
             // CQRS
-            //services.StartEventReciever();
             services.StartSubscriber<Ticket>();
 
             // Add MVC

--- a/Erazer.Web.ReadAPI/appsettings.json
+++ b/Erazer.Web.ReadAPI/appsettings.json
@@ -17,6 +17,6 @@
     "ConnectionString": "http://localhost:3000/internal/broadcast"
   },
   "EventStoreSettings": {
-    "ConnectionString": "ConnectTo=tcp://admin:changeit@localhost:1113; HeartBeatTimeout=50"
+    "ConnectionString": "ConnectTo=tcp://admin:changeit@localhost:1113"
   }
 }

--- a/Erazer.Web.ReadAPI/appsettings.json
+++ b/Erazer.Web.ReadAPI/appsettings.json
@@ -15,5 +15,8 @@
   },
   "WebsocketSettings": {
     "ConnectionString": "http://localhost:3000/internal/broadcast"
+  },
+  "EventStoreSettings": {
+    "ConnectionString": "ConnectTo=tcp://admin:changeit@localhost:1113; HeartBeatTimeout=50"
   }
 }

--- a/Erazer.Web.ReadAPI/startmongo.ps1
+++ b/Erazer.Web.ReadAPI/startmongo.ps1
@@ -1,1 +1,1 @@
-& "C:\Program Files\MongoDB\Server\3.4\bin\mongod.exe" --dbpath='C:\MongoDbData\ErazerCQRS'
+& "C:\Program Files\MongoDB\Server\3.4\bin\mongod.exe" --dbpath='D:\MongoDB\data'

--- a/Erazer.Web.WriteAPI/Startup.cs
+++ b/Erazer.Web.WriteAPI/Startup.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using AutoMapper;
 using Erazer.DAL.Cache;
-using Erazer.DAL.WriteModel;
 using Erazer.Framework.Cache;
 using Erazer.Framework.Domain;
 using Erazer.Framework.Events;
@@ -11,11 +10,11 @@ using EventStore.ClientAPI;
 using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Azure.ServiceBus;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ServiceStack.Redis;
+using Erazer.DAL.Infrastucture.EventStore;
 
 namespace Erazer.Web.WriteAPI
 {
@@ -46,7 +45,7 @@ namespace Erazer.Web.WriteAPI
             // Add 'Infrasructure' Providers
             services.AddSingletonFactory<IEventStoreConnection, EventStoreFactory>();
             services.AddSingletonFactory<IRedisClientsManager, RedisFactory>();
-            services.AddSingletonFactory<IQueueClient, QueueClientFactory>();
+            // services.AddSingletonFactory<IQueueClient, QueueClientFactory>();
 
             services.AddAutoMapper();
             services.AddMediatR();
@@ -60,11 +59,11 @@ namespace Erazer.Web.WriteAPI
             //services.AddScoped<IAggregateRepository, AggregateRepository>();
 
             // CQRS
-            services.AddScoped<IEventPublisher, EventPublisher>();
+            // services.AddScoped<IEventPublisher, EventPublisher>();
 
             // Add MVC
             services.AddCors();
-            services.AddMvcCore().AddJsonFormatters();
+            services.AddMvcCore().AddJsonFormatters();           
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Erazer.Web.WriteAPI/Startup.cs
+++ b/Erazer.Web.WriteAPI/Startup.cs
@@ -63,7 +63,7 @@ namespace Erazer.Web.WriteAPI
 
             // Add MVC
             services.AddCors();
-            services.AddMvcCore().AddJsonFormatters();           
+            services.AddMvcCore().AddJsonFormatters();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Erazer.Web.WriteAPI/start_eventstore.ps1
+++ b/Erazer.Web.WriteAPI/start_eventstore.ps1
@@ -1,1 +1,1 @@
-& "E:\EventStore\EventStore.ClusterNode.exe"
+& "D:\EventStore\EventStore.ClusterNode.exe" --run-projections=all

--- a/run.ps1
+++ b/run.ps1
@@ -24,6 +24,8 @@ cd Erazer.Web.ReadAPI
 dotnet run 
 }
 
+Start-Sleep -s 5
+
 start powershell { 
 cd Erazer.Web.WriteAPI
 dotnet run 


### PR DESCRIPTION
- Refactored `Azure Service Bus` to `Persisted Subscription` (competing consumers)

Azure Service Bus was used to communicate **events** from writeside to readside of the CQRS application.

![image](https://user-images.githubusercontent.com/6287467/35876521-d5de9a76-0b72-11e8-8d96-10a178a73158.png)

- Left old situation (Azure Service bus was the used service bus)
- Right new situation (this PR, utilized a build in bus from EventStore)

## Benefits
Transaction scope is easier to maintain